### PR TITLE
Make it python 2 compatible

### DIFF
--- a/httpie_django_auth.py
+++ b/httpie_django_auth.py
@@ -6,8 +6,14 @@ import json
 import os
 import shlex
 import subprocess
-from urllib.parse import urlsplit
 
+try:
+    # If Python 3
+    from urllib.parse import urlsplit
+except ImportError:
+    # If Python 2
+    from urlparse import urlsplit
+    
 from httpie.plugins import AuthPlugin, builtin
 
 


### PR DESCRIPTION
`urlsplit` is to be found in a different location